### PR TITLE
Merge upstream changes

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -6,6 +6,7 @@ jobs:
   lint:
     name: "Lint"
     runs-on: "ubuntu-latest"
+    continue-on-error: ${{ matrix.experimental }}
     strategy:
       fail-fast: false
       matrix:
@@ -23,14 +24,22 @@ jobs:
           - "8.1"
           - "8.2"
           - "8.3"
+        experimental:
+          - false
+        include:
+          - php-version: "8.4"
+            experimental: true
+            composer-options: "--ignore-platform-reqs"
     steps:
-      - uses: "actions/checkout@v3"
+      - uses: "actions/checkout@v4"
       - uses: "shivammathur/setup-php@v2"
         with:
           php-version: "${{ matrix.php-version }}"
           ini-values: error_reporting=-1, display_errors=On
           coverage: "none"
       - uses: "ramsey/composer-install@v2"
+        with:
+          composer-options: "${{ matrix.composer-options }}"
       - name: "Run the linter"
         run: "composer lint -- --colors"
 
@@ -38,7 +47,7 @@ jobs:
     name: "Static Analysis"
     runs-on: "ubuntu-latest"
     steps:
-      - uses: "actions/checkout@v3"
+      - uses: "actions/checkout@v4"
       - uses: "shivammathur/setup-php@v2"
         with:
           php-version: "7.4"

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -41,8 +41,8 @@ jobs:
       - uses: "actions/checkout@v3"
       - uses: "shivammathur/setup-php@v2"
         with:
-          php-version: "7.4"
-          tools: "phpstan:1.8.11"
+          php-version: "8.2"
+          tools: "phpstan:1.10.57"
           coverage: "none"
       - uses: "ramsey/composer-install@v2"
       - name: "Run PHPStan"

--- a/changelog.txt
+++ b/changelog.txt
@@ -18,6 +18,19 @@
 Version History
 ===============
 
+1.9.23: [2023-10-19] James Heinrich :: 1.9.23-202310190849
+	» add detection support for 7-zip archives
+	* #424 RIFF Undefined index "data"
+	* #421 tag.xmp remove GLOBALS
+	* #419 Quicktime Undefined index "time_scale"
+	* #418 tag.xmp zero-length fread
+	* #414 Quicktime bitrate for mp4 audio
+	* #413 Quicktime audio metadata
+	* #410 MPEG-1 pixel aspect ratio
+	* #407 PHP 8.1 compatibility
+	* #404 guard against division by zero
+	* #402 remove utf8_encode/utf8_decode
+
 1.9.22: [2022-09-29] James Heinrich :: 1.9.22-202207161647
 	* bugfix #387 fails to detect h265 video codec (QuickTime)
 	* bugfix #385 Quicktime extended atom size

--- a/getid3/extension.cache.dbm.php
+++ b/getid3/extension.cache.dbm.php
@@ -243,7 +243,7 @@ class getID3_cached_dbm extends getID3
 		$result = parent::analyze($filename, $filesize, $original_filename, $fp);
 
 		// Save result
-		if (isset($key) && file_exists($filename)) {
+		if ($key !== null) {
 			dba_insert($key, serialize($result), $this->dba);
 		}
 

--- a/getid3/getid3.lib.php
+++ b/getid3/getid3.lib.php
@@ -115,7 +115,9 @@ class getid3_lib
 		// check if integers are 64-bit
 		static $hasINT64 = null;
 		if ($hasINT64 === null) { // 10x faster than is_null()
-			$hasINT64 = is_int(pow(2, 31)); // 32-bit int are limited to (2^31)-1
+			/** @var int|float|false $bigInt */
+			$bigInt = pow(2, 31);
+			$hasINT64 = is_int($bigInt); // 32-bit int are limited to (2^31)-1
 			if (!$hasINT64 && !defined('PHP_INT_MIN')) {
 				define('PHP_INT_MIN', ~PHP_INT_MAX);
 			}
@@ -1517,7 +1519,7 @@ class getid3_lib
 	public static function GetDataImageSize($imgData, &$imageinfo=array()) {
 		if (PHP_VERSION_ID >= 50400) {
 			$GetDataImageSize = @getimagesizefromstring($imgData, $imageinfo);
-			if ($GetDataImageSize === false || !isset($GetDataImageSize[0], $GetDataImageSize[1])) {
+			if ($GetDataImageSize === false) {
 				return false;
 			}
 			$GetDataImageSize['height'] = $GetDataImageSize[0];
@@ -1545,7 +1547,7 @@ class getid3_lib
 				fwrite($tmp, $imgData);
 				fclose($tmp);
 				$GetDataImageSize = @getimagesize($tempfilename, $imageinfo);
-				if (($GetDataImageSize === false) || !isset($GetDataImageSize[0]) || !isset($GetDataImageSize[1])) {
+				if ($GetDataImageSize === false) {
 					return false;
 				}
 				$GetDataImageSize['height'] = $GetDataImageSize[0];

--- a/getid3/getid3.php
+++ b/getid3/getid3.php
@@ -387,7 +387,7 @@ class getID3
 	 */
 	protected $startup_warning = '';
 
-	const VERSION           = '1.9.22-202308100852';
+	const VERSION           = '1.9.23-202310190849';
 	const FREAD_BUFFER_SIZE = 32768;
 
 	const ATTACHMENTS_NONE   = false;

--- a/getid3/getid3.php
+++ b/getid3/getid3.php
@@ -387,7 +387,7 @@ class getID3
 	 */
 	protected $startup_warning = '';
 
-	const VERSION           = '1.9.23-202311100900';
+	const VERSION           = '1.9.23-202312292105';
 	const FREAD_BUFFER_SIZE = 32768;
 
 	const ATTACHMENTS_NONE   = false;

--- a/getid3/getid3.php
+++ b/getid3/getid3.php
@@ -387,7 +387,7 @@ class getID3
 	 */
 	protected $startup_warning = '';
 
-	const VERSION           = '1.9.23-202403260825';
+	const VERSION           = '1.9.23-202404261550';
 	const FREAD_BUFFER_SIZE = 32768;
 
 	const ATTACHMENTS_NONE   = false;

--- a/getid3/getid3.php
+++ b/getid3/getid3.php
@@ -387,7 +387,7 @@ class getID3
 	 */
 	protected $startup_warning = '';
 
-	const VERSION           = '1.9.23-202312292105';
+	const VERSION           = '1.9.23-202402191012';
 	const FREAD_BUFFER_SIZE = 32768;
 
 	const ATTACHMENTS_NONE   = false;
@@ -1476,6 +1476,16 @@ class getID3
 
 
 				// Misc other formats
+
+				// GPX - data         - GPS Exchange Format
+				'gpx' => array (
+							'pattern'   => '^<\\?xml [^>]+>[\s]*<gpx ',
+							'group'     => 'misc',
+							'module'    => 'gpx',
+							'mime_type' => 'application/gpx+xml',
+							'fail_id3'  => 'ERROR',
+							'fail_ape'  => 'ERROR',
+						),
 
 				// PAR2 - data        - Parity Volume Set Specification 2.0
 				'par2' => array (

--- a/getid3/getid3.php
+++ b/getid3/getid3.php
@@ -387,7 +387,7 @@ class getID3
 	 */
 	protected $startup_warning = '';
 
-	const VERSION           = '1.9.23-202311041554';
+	const VERSION           = '1.9.23-202311100900';
 	const FREAD_BUFFER_SIZE = 32768;
 
 	const ATTACHMENTS_NONE   = false;

--- a/getid3/getid3.php
+++ b/getid3/getid3.php
@@ -387,7 +387,7 @@ class getID3
 	 */
 	protected $startup_warning = '';
 
-	const VERSION           = '1.9.23-202310190849';
+	const VERSION           = '1.9.23-202311041554';
 	const FREAD_BUFFER_SIZE = 32768;
 
 	const ATTACHMENTS_NONE   = false;

--- a/getid3/getid3.php
+++ b/getid3/getid3.php
@@ -387,7 +387,7 @@ class getID3
 	 */
 	protected $startup_warning = '';
 
-	const VERSION           = '1.9.23-202403230855';
+	const VERSION           = '1.9.23-202403260825';
 	const FREAD_BUFFER_SIZE = 32768;
 
 	const ATTACHMENTS_NONE   = false;

--- a/getid3/getid3.php
+++ b/getid3/getid3.php
@@ -409,10 +409,10 @@ class getID3
 		$memoryLimit = ini_get('memory_limit');
 		if (preg_match('#([0-9]+) ?M#i', $memoryLimit, $matches)) {
 			// could be stored as "16M" rather than 16777216 for example
-			$memoryLimit = $matches[1] * 1048576;
+			$memoryLimit = (int) $matches[1] * 1048576;
 		} elseif (preg_match('#([0-9]+) ?G#i', $memoryLimit, $matches)) { // The 'G' modifier is available since PHP 5.1.0
 			// could be stored as "2G" rather than 2147483648 for example
-			$memoryLimit = $matches[1] * 1073741824;
+			$memoryLimit = (int) $matches[1] * 1073741824;
 		}
 		$this->memory_limit = $memoryLimit;
 
@@ -446,7 +446,7 @@ class getID3
 			}
 			// Check for magic_quotes_gpc
 			if (function_exists('get_magic_quotes_gpc')) {
-				if (get_magic_quotes_gpc()) { // @phpstan-ignore-line
+				if (get_magic_quotes_gpc()) {
 					$this->startup_error .= 'magic_quotes_gpc must be disabled before running getID3(). Surround getid3 block by set_magic_quotes_gpc(0) and set_magic_quotes_gpc(1).'."\n";
 				}
 			}

--- a/getid3/getid3.php
+++ b/getid3/getid3.php
@@ -387,7 +387,7 @@ class getID3
 	 */
 	protected $startup_warning = '';
 
-	const VERSION           = '1.9.23-202402191012';
+	const VERSION           = '1.9.23-202403230855';
 	const FREAD_BUFFER_SIZE = 32768;
 
 	const ATTACHMENTS_NONE   = false;

--- a/getid3/module.audio-video.asf.php
+++ b/getid3/module.audio-video.asf.php
@@ -499,13 +499,17 @@ class getid3_asf extends getid3_handler
 					$offset += 2;
 					$thisfile_asf_scriptcommandobject['command_types_count']  = getid3_lib::LittleEndian2Int(substr($ASFHeaderData, $offset, 2));
 					$offset += 2;
-					for ($CommandTypesCounter = 0; $CommandTypesCounter < $thisfile_asf_scriptcommandobject['command_types_count']; $CommandTypesCounter++) {
-						$CommandTypeNameLength = getid3_lib::LittleEndian2Int(substr($ASFHeaderData, $offset, 2)) * 2; // 2 bytes per character
-						$offset += 2;
-						$thisfile_asf_scriptcommandobject['command_types'][$CommandTypesCounter]['name'] = substr($ASFHeaderData, $offset, $CommandTypeNameLength);
-						$offset += $CommandTypeNameLength;
+					if ($thisfile_asf_scriptcommandobject['command_types_count'] > 0) {
+						$thisfile_asf_scriptcommandobject['command_types'] = array();
+						for ($CommandTypesCounter = 0; $CommandTypesCounter < (int) $thisfile_asf_scriptcommandobject['command_types_count']; $CommandTypesCounter++) {
+							$CommandTypeNameLength = getid3_lib::LittleEndian2Int(substr($ASFHeaderData, $offset, 2)) * 2; // 2 bytes per character
+							$offset += 2;
+							$thisfile_asf_scriptcommandobject['command_types'][$CommandTypesCounter] = array();
+							$thisfile_asf_scriptcommandobject['command_types'][$CommandTypesCounter]['name'] = substr($ASFHeaderData, $offset, $CommandTypeNameLength);
+							$offset += $CommandTypeNameLength;
+						}
 					}
-					for ($CommandsCounter = 0; $CommandsCounter < $thisfile_asf_scriptcommandobject['commands_count']; $CommandsCounter++) {
+					for ($CommandsCounter = 0; $CommandsCounter < (int) $thisfile_asf_scriptcommandobject['commands_count']; $CommandsCounter++) {
 						$thisfile_asf_scriptcommandobject['commands'][$CommandsCounter]['presentation_time']  = getid3_lib::LittleEndian2Int(substr($ASFHeaderData, $offset, 4));
 						$offset += 4;
 						$thisfile_asf_scriptcommandobject['commands'][$CommandsCounter]['type_index']         = getid3_lib::LittleEndian2Int(substr($ASFHeaderData, $offset, 2));
@@ -554,6 +558,8 @@ class getid3_asf extends getid3_handler
 						break;
 					}
 					$thisfile_asf_markerobject['markers_count'] = getid3_lib::LittleEndian2Int(substr($ASFHeaderData, $offset, 4));
+					/** @var int|float|false $totalMakersCount */
+					$totalMakersCount = $thisfile_asf_markerobject['markers_count'];
 					$offset += 4;
 					$thisfile_asf_markerobject['reserved_2'] = getid3_lib::LittleEndian2Int(substr($ASFHeaderData, $offset, 2));
 					$offset += 2;
@@ -565,7 +571,8 @@ class getid3_asf extends getid3_handler
 					$offset += 2;
 					$thisfile_asf_markerobject['name'] = substr($ASFHeaderData, $offset, $thisfile_asf_markerobject['name_length']);
 					$offset += $thisfile_asf_markerobject['name_length'];
-					for ($MarkersCounter = 0; $MarkersCounter < $thisfile_asf_markerobject['markers_count']; $MarkersCounter++) {
+					for ($MarkersCounter = 0; $MarkersCounter < $totalMakersCount; $MarkersCounter++) {
+						$thisfile_asf_markerobject['markers'][$MarkersCounter] = array();
 						$thisfile_asf_markerobject['markers'][$MarkersCounter]['offset']  = getid3_lib::LittleEndian2Int(substr($ASFHeaderData, $offset, 8));
 						$offset += 8;
 						$thisfile_asf_markerobject['markers'][$MarkersCounter]['presentation_time']         = getid3_lib::LittleEndian2Int(substr($ASFHeaderData, $offset, 8));
@@ -615,7 +622,7 @@ class getid3_asf extends getid3_handler
 					}
 					$thisfile_asf_bitratemutualexclusionobject['stream_numbers_count'] = getid3_lib::LittleEndian2Int(substr($ASFHeaderData, $offset, 2));
 					$offset += 2;
-					for ($StreamNumberCounter = 0; $StreamNumberCounter < $thisfile_asf_bitratemutualexclusionobject['stream_numbers_count']; $StreamNumberCounter++) {
+					for ($StreamNumberCounter = 0; $StreamNumberCounter < (int) $thisfile_asf_bitratemutualexclusionobject['stream_numbers_count']; $StreamNumberCounter++) {
 						$thisfile_asf_bitratemutualexclusionobject['stream_numbers'][$StreamNumberCounter] = getid3_lib::LittleEndian2Int(substr($ASFHeaderData, $offset, 2));
 						$offset += 2;
 					}
@@ -759,7 +766,7 @@ class getid3_asf extends getid3_handler
 					$thisfile_asf_extendedcontentdescriptionobject['objectsize']                = $NextObjectSize;
 					$thisfile_asf_extendedcontentdescriptionobject['content_descriptors_count'] = getid3_lib::LittleEndian2Int(substr($ASFHeaderData, $offset, 2));
 					$offset += 2;
-					for ($ExtendedContentDescriptorsCounter = 0; $ExtendedContentDescriptorsCounter < $thisfile_asf_extendedcontentdescriptionobject['content_descriptors_count']; $ExtendedContentDescriptorsCounter++) {
+					for ($ExtendedContentDescriptorsCounter = 0; $ExtendedContentDescriptorsCounter < (int) $thisfile_asf_extendedcontentdescriptionobject['content_descriptors_count']; $ExtendedContentDescriptorsCounter++) {
 						// shortcut
 						$thisfile_asf_extendedcontentdescriptionobject['content_descriptors'][$ExtendedContentDescriptorsCounter] = array();
 						$thisfile_asf_extendedcontentdescriptionobject_contentdescriptor_current                 = &$thisfile_asf_extendedcontentdescriptionobject['content_descriptors'][$ExtendedContentDescriptorsCounter];
@@ -957,7 +964,8 @@ class getid3_asf extends getid3_handler
 					$thisfile_asf_streambitratepropertiesobject['objectsize']                = $NextObjectSize;
 					$thisfile_asf_streambitratepropertiesobject['bitrate_records_count']     = getid3_lib::LittleEndian2Int(substr($ASFHeaderData, $offset, 2));
 					$offset += 2;
-					for ($BitrateRecordsCounter = 0; $BitrateRecordsCounter < $thisfile_asf_streambitratepropertiesobject['bitrate_records_count']; $BitrateRecordsCounter++) {
+					for ($BitrateRecordsCounter = 0; $BitrateRecordsCounter < (int) $thisfile_asf_streambitratepropertiesobject['bitrate_records_count']; $BitrateRecordsCounter++) {
+						$thisfile_asf_streambitratepropertiesobject['bitrate_records'][$BitrateRecordsCounter] = array();
 						$thisfile_asf_streambitratepropertiesobject['bitrate_records'][$BitrateRecordsCounter]['flags_raw'] = getid3_lib::LittleEndian2Int(substr($ASFHeaderData, $offset, 2));
 						$offset += 2;
 						$thisfile_asf_streambitratepropertiesobject['bitrate_records'][$BitrateRecordsCounter]['flags']['stream_number'] = $thisfile_asf_streambitratepropertiesobject['bitrate_records'][$BitrateRecordsCounter]['flags_raw'] & 0x007F;
@@ -1006,7 +1014,7 @@ class getid3_asf extends getid3_handler
 		if (isset($thisfile_asf_streambitratepropertiesobject['bitrate_records_count'])) {
 			$ASFbitrateAudio = 0;
 			$ASFbitrateVideo = 0;
-			for ($BitrateRecordsCounter = 0; $BitrateRecordsCounter < $thisfile_asf_streambitratepropertiesobject['bitrate_records_count']; $BitrateRecordsCounter++) {
+			for ($BitrateRecordsCounter = 0; $BitrateRecordsCounter < (int) $thisfile_asf_streambitratepropertiesobject['bitrate_records_count']; $BitrateRecordsCounter++) {
 				if (isset($thisfile_asf_codeclistobject['codec_entries'][$BitrateRecordsCounter])) {
 					switch ($thisfile_asf_codeclistobject['codec_entries'][$BitrateRecordsCounter]['type_raw']) {
 						case 1:
@@ -1030,7 +1038,7 @@ class getid3_asf extends getid3_handler
 				$thisfile_video['bitrate'] = $ASFbitrateVideo;
 			}
 		}
-		if (isset($thisfile_asf['stream_properties_object']) && is_array($thisfile_asf['stream_properties_object'])) {
+		if (isset($thisfile_asf['stream_properties_object'])) {
 
 			$thisfile_audio['bitrate'] = 0;
 			$thisfile_video['bitrate'] = 0;
@@ -1067,7 +1075,7 @@ class getid3_asf extends getid3_handler
 						}
 
 						if (!empty($thisfile_asf['stream_bitrate_properties_object']['bitrate_records'])) { // @phpstan-ignore-line
-							foreach ($thisfile_asf['stream_bitrate_properties_object']['bitrate_records'] as $dummy => $dataarray) {
+							foreach ($thisfile_asf['stream_bitrate_properties_object']['bitrate_records'] as $dummy => $dataarray) { // @phpstan-ignore-line
 								if (isset($dataarray['flags']['stream_number']) && ($dataarray['flags']['stream_number'] == $streamnumber)) {
 									$thisfile_asf_audiomedia_currentstream['bitrate'] = $dataarray['bitrate'];
 									$thisfile_audio['bitrate'] += $dataarray['bitrate'];
@@ -1153,7 +1161,7 @@ class getid3_asf extends getid3_handler
 						$thisfile_asf_videomedia_currentstream['format_data']['codec_data']       = substr($streamdata['type_specific_data'], $videomediaoffset);
 
 						if (!empty($thisfile_asf['stream_bitrate_properties_object']['bitrate_records'])) { // @phpstan-ignore-line
-							foreach ($thisfile_asf['stream_bitrate_properties_object']['bitrate_records'] as $dummy => $dataarray) {
+							foreach ($thisfile_asf['stream_bitrate_properties_object']['bitrate_records'] as $dummy => $dataarray) { // @phpstan-ignore-line
 								if (isset($dataarray['flags']['stream_number']) && ($dataarray['flags']['stream_number'] == $streamnumber)) {
 									$thisfile_asf_videomedia_currentstream['bitrate'] = $dataarray['bitrate'];
 									$thisfile_video['streams'][$streamnumber]['bitrate'] = $dataarray['bitrate'];
@@ -1266,10 +1274,13 @@ class getid3_asf extends getid3_handler
 					$thisfile_asf_simpleindexobject['maximum_packet_count']      = getid3_lib::LittleEndian2Int(substr($SimpleIndexObjectData, $offset, 4));
 					$offset += 4;
 					$thisfile_asf_simpleindexobject['index_entries_count']       = getid3_lib::LittleEndian2Int(substr($SimpleIndexObjectData, $offset, 4));
+					/** @var int|float|false $totalIndexEntriesCount */
+					$totalIndexEntriesCount = $thisfile_asf_simpleindexobject['index_entries_count'];
 					$offset += 4;
 
-					$IndexEntriesData = $SimpleIndexObjectData.$this->fread(6 * $thisfile_asf_simpleindexobject['index_entries_count']);
-					for ($IndexEntriesCounter = 0; $IndexEntriesCounter < $thisfile_asf_simpleindexobject['index_entries_count']; $IndexEntriesCounter++) {
+					$IndexEntriesData = $SimpleIndexObjectData.$this->fread(6 * $totalIndexEntriesCount);
+					for ($IndexEntriesCounter = 0; $IndexEntriesCounter < $totalIndexEntriesCount; $IndexEntriesCounter++) {
+						$thisfile_asf_simpleindexobject['index_entries'][$IndexEntriesCounter]                  = array();
 						$thisfile_asf_simpleindexobject['index_entries'][$IndexEntriesCounter]['packet_number'] = getid3_lib::LittleEndian2Int(substr($IndexEntriesData, $offset, 4));
 						$offset += 4;
 						$thisfile_asf_simpleindexobject['index_entries'][$IndexEntriesCounter]['packet_count']  = getid3_lib::LittleEndian2Int(substr($IndexEntriesData, $offset, 4));
@@ -1320,9 +1331,10 @@ class getid3_asf extends getid3_handler
 					$offset += 4;
 
 					$ASFIndexObjectData .= $this->fread(4 * $thisfile_asf_asfindexobject['index_specifiers_count']);
-					for ($IndexSpecifiersCounter = 0; $IndexSpecifiersCounter < $thisfile_asf_asfindexobject['index_specifiers_count']; $IndexSpecifiersCounter++) {
+					for ($IndexSpecifiersCounter = 0; $IndexSpecifiersCounter < (int) $thisfile_asf_asfindexobject['index_specifiers_count']; $IndexSpecifiersCounter++) {
 						$IndexSpecifierStreamNumber = getid3_lib::LittleEndian2Int(substr($ASFIndexObjectData, $offset, 2));
 						$offset += 2;
+						$thisfile_asf_asfindexobject['index_specifiers'][$IndexSpecifiersCounter]                    = array();
 						$thisfile_asf_asfindexobject['index_specifiers'][$IndexSpecifiersCounter]['stream_number']   = $IndexSpecifierStreamNumber;
 						$thisfile_asf_asfindexobject['index_specifiers'][$IndexSpecifiersCounter]['index_type']      = getid3_lib::LittleEndian2Int(substr($ASFIndexObjectData, $offset, 2));
 						$offset += 2;
@@ -1331,17 +1343,19 @@ class getid3_asf extends getid3_handler
 
 					$ASFIndexObjectData .= $this->fread(4);
 					$thisfile_asf_asfindexobject['index_entry_count'] = getid3_lib::LittleEndian2Int(substr($ASFIndexObjectData, $offset, 4));
+					/** @var int|float|false $totalIndexEntryCount */
+					$totalIndexEntryCount = $thisfile_asf_asfindexobject['index_entry_count'];
 					$offset += 4;
 
 					$ASFIndexObjectData .= $this->fread(8 * $thisfile_asf_asfindexobject['index_specifiers_count']);
-					for ($IndexSpecifiersCounter = 0; $IndexSpecifiersCounter < $thisfile_asf_asfindexobject['index_specifiers_count']; $IndexSpecifiersCounter++) {
+					for ($IndexSpecifiersCounter = 0; $IndexSpecifiersCounter < (int) $thisfile_asf_asfindexobject['index_specifiers_count']; $IndexSpecifiersCounter++) {
 						$thisfile_asf_asfindexobject['block_positions'][$IndexSpecifiersCounter] = getid3_lib::LittleEndian2Int(substr($ASFIndexObjectData, $offset, 8));
 						$offset += 8;
 					}
 
 					$ASFIndexObjectData .= $this->fread(4 * $thisfile_asf_asfindexobject['index_specifiers_count'] * $thisfile_asf_asfindexobject['index_entry_count']);
-					for ($IndexEntryCounter = 0; $IndexEntryCounter < $thisfile_asf_asfindexobject['index_entry_count']; $IndexEntryCounter++) {
-						for ($IndexSpecifiersCounter = 0; $IndexSpecifiersCounter < $thisfile_asf_asfindexobject['index_specifiers_count']; $IndexSpecifiersCounter++) {
+					for ($IndexEntryCounter = 0; $IndexEntryCounter < $totalIndexEntryCount; $IndexEntryCounter++) {
+						for ($IndexSpecifiersCounter = 0; $IndexSpecifiersCounter < (int) $thisfile_asf_asfindexobject['index_specifiers_count']; $IndexSpecifiersCounter++) {
 							$thisfile_asf_asfindexobject['offsets'][$IndexSpecifiersCounter][$IndexEntryCounter] = getid3_lib::LittleEndian2Int(substr($ASFIndexObjectData, $offset, 4));
 							$offset += 4;
 						}

--- a/getid3/module.audio-video.mpeg.php
+++ b/getid3/module.audio-video.mpeg.php
@@ -292,6 +292,10 @@ class getid3_mpeg extends getid3_handler
 						$GOPheader['time_code'] = sprintf('%02d'.$time_code_separator.'%02d'.$time_code_separator.'%02d'.$time_code_separator.'%02d', $GOPheader['time_code_hours'], $GOPheader['time_code_minutes'], $GOPheader['time_code_seconds'], $GOPheader['time_code_pictures']);
 
 						$info['mpeg']['group_of_pictures'][] = $GOPheader;
+					} else {
+						// https://github.com/JamesHeinrich/getID3/issues/440
+						$this->warning('group_of_pictures['.$GOPcounter.'] no valid bitratemode');
+						$info['mpeg']['group_of_pictures'][] = array();
 					}
 					break;
 

--- a/getid3/module.audio-video.quicktime.php
+++ b/getid3/module.audio-video.quicktime.php
@@ -2122,7 +2122,7 @@ $this->warning('incomplete/incorrect handling of "stsd" with Parrot metadata in 
 					$atom_structure['ES_DescrTag'] = getid3_lib::BigEndian2Int(substr($atom_data, $esds_offset, 1));
 					$esds_offset += 1;
 					if ($atom_structure['ES_DescrTag'] != 0x03) {
-						$this->warning('expecting esds.ES_DescrTag = 0x03, found 0x'.getid3_lib::PrintHexBytes($atom_structure['ES_DescrTag']).'), at offset '.$atom_structure['offset']);
+						$this->warning('expecting esds.ES_DescrTag = 0x03, found 0x'.sprintf('%02X', $atom_structure['ES_DescrTag']).', at offset '.$atom_structure['offset']);
 						break;
 					}
 					$atom_structure['ES_DescrSize'] = $this->quicktime_read_mp4_descr_length($atom_data, $esds_offset);
@@ -2151,7 +2151,7 @@ $this->warning('incomplete/incorrect handling of "stsd" with Parrot metadata in 
 					$atom_structure['ES_DecoderConfigDescrTag'] = getid3_lib::BigEndian2Int(substr($atom_data, $esds_offset, 1));
 					$esds_offset += 1;
 					if ($atom_structure['ES_DecoderConfigDescrTag'] != 0x04) {
-						$this->warning('expecting esds.ES_DecoderConfigDescrTag = 0x04, found 0x'.getid3_lib::PrintHexBytes($atom_structure['ES_DecoderConfigDescrTag']).'), at offset '.$atom_structure['offset']);
+						$this->warning('expecting esds.ES_DecoderConfigDescrTag = 0x04, found 0x'.sprintf('%02X', $atom_structure['ES_DecoderConfigDescrTag']).', at offset '.$atom_structure['offset']);
 						break;
 					}
 					$atom_structure['ES_DecoderConfigDescrTagSize'] = $this->quicktime_read_mp4_descr_length($atom_data, $esds_offset);
@@ -2182,7 +2182,7 @@ $this->warning('incomplete/incorrect handling of "stsd" with Parrot metadata in 
 					$atom_structure['ES_DecSpecificInfoTag'] = getid3_lib::BigEndian2Int(substr($atom_data, $esds_offset, 1));
 					$esds_offset += 1;
 					if ($atom_structure['ES_DecSpecificInfoTag'] != 0x05) {
-						$this->warning('expecting esds.ES_DecSpecificInfoTag = 0x05, found 0x'.getid3_lib::PrintHexBytes($atom_structure['ES_DecSpecificInfoTag']).'), at offset '.$atom_structure['offset']);
+						$this->warning('expecting esds.ES_DecSpecificInfoTag = 0x05, found 0x'.sprintf('%02X', $atom_structure['ES_DecSpecificInfoTag']).', at offset '.$atom_structure['offset']);
 						break;
 					}
 					$atom_structure['ES_DecSpecificInfoTagSize'] = $this->quicktime_read_mp4_descr_length($atom_data, $esds_offset);
@@ -2193,7 +2193,7 @@ $this->warning('incomplete/incorrect handling of "stsd" with Parrot metadata in 
 					$atom_structure['ES_SLConfigDescrTag'] = getid3_lib::BigEndian2Int(substr($atom_data, $esds_offset, 1));
 					$esds_offset += 1;
 					if ($atom_structure['ES_SLConfigDescrTag'] != 0x06) {
-						$this->warning('expecting esds.ES_SLConfigDescrTag = 0x05, found 0x'.getid3_lib::PrintHexBytes($atom_structure['ES_SLConfigDescrTag']).'), at offset '.$atom_structure['offset']);
+						$this->warning('expecting esds.ES_SLConfigDescrTag = 0x05, found 0x'.sprintf('%02X', $atom_structure['ES_SLConfigDescrTag']).', at offset '.$atom_structure['offset']);
 						break;
 					}
 					$atom_structure['ES_SLConfigDescrTagSize'] = $this->quicktime_read_mp4_descr_length($atom_data, $esds_offset);

--- a/getid3/module.audio-video.quicktime.php
+++ b/getid3/module.audio-video.quicktime.php
@@ -156,27 +156,27 @@ class getid3_quicktime extends getid3_handler
 					@list($dummy, $lat_sign, $lat_deg, $lat_deg_dec, $lon_sign, $lon_deg, $lon_deg_dec, $dummy, $alt_sign, $alt_deg, $alt_deg_dec) = $matches;
 
 					if (strlen($lat_deg) == 2) {        // [+-]DD.D
-						$ISO6709parsed['latitude'] = (($lat_sign == '-') ? -1 : 1) * floatval(ltrim($lat_deg, '0').$lat_deg_dec);
+						$ISO6709parsed['latitude'] = (($lat_sign == '-') ? -1 : 1) * (float) (ltrim($lat_deg, '0').$lat_deg_dec);
 					} elseif (strlen($lat_deg) == 4) {  // [+-]DDMM.M
-						$ISO6709parsed['latitude'] = (($lat_sign == '-') ? -1 : 1) * floatval(ltrim(substr($lat_deg, 0, 2), '0')) + floatval(ltrim(substr($lat_deg, 2, 2), '0').$lat_deg_dec / 60);
+						$ISO6709parsed['latitude'] = (($lat_sign == '-') ? -1 : 1) * (int) ltrim(substr($lat_deg, 0, 2), '0') + ((float) (ltrim(substr($lat_deg, 2, 2), '0').$lat_deg_dec) / 60);
 					} elseif (strlen($lat_deg) == 6) {  // [+-]DDMMSS.S
-						$ISO6709parsed['latitude'] = (($lat_sign == '-') ? -1 : 1) * floatval(ltrim(substr($lat_deg, 0, 2), '0')) + floatval((int) ltrim(substr($lat_deg, 2, 2), '0') / 60) + floatval(ltrim(substr($lat_deg, 4, 2), '0').$lat_deg_dec / 3600);
+						$ISO6709parsed['latitude'] = (($lat_sign == '-') ? -1 : 1) * (int) ltrim(substr($lat_deg, 0, 2), '0') + ((int) ltrim(substr($lat_deg, 2, 2), '0') / 60) + ((float) (ltrim(substr($lat_deg, 4, 2), '0').$lat_deg_dec) / 3600);
 					}
 
 					if (strlen($lon_deg) == 3) {        // [+-]DDD.D
-						$ISO6709parsed['longitude'] = (($lon_sign == '-') ? -1 : 1) * floatval(ltrim($lon_deg, '0').$lon_deg_dec);
+						$ISO6709parsed['longitude'] = (($lon_sign == '-') ? -1 : 1) * (float) (ltrim($lon_deg, '0').$lon_deg_dec);
 					} elseif (strlen($lon_deg) == 5) {  // [+-]DDDMM.M
-						$ISO6709parsed['longitude'] = (($lon_sign == '-') ? -1 : 1) * floatval(ltrim(substr($lon_deg, 0, 2), '0')) + floatval(ltrim(substr($lon_deg, 2, 2), '0').$lon_deg_dec / 60);
+						$ISO6709parsed['longitude'] = (($lon_sign == '-') ? -1 : 1) * (int) ltrim(substr($lon_deg, 0, 2), '0') + ((float) (ltrim(substr($lon_deg, 2, 2), '0').$lon_deg_dec) / 60);
 					} elseif (strlen($lon_deg) == 7) {  // [+-]DDDMMSS.S
-						$ISO6709parsed['longitude'] = (($lon_sign == '-') ? -1 : 1) * floatval(ltrim(substr($lon_deg, 0, 2), '0')) + floatval((int) ltrim(substr($lon_deg, 2, 2), '0') / 60) + floatval(ltrim(substr($lon_deg, 4, 2), '0').$lon_deg_dec / 3600);
+						$ISO6709parsed['longitude'] = (($lon_sign == '-') ? -1 : 1) * (int) ltrim(substr($lon_deg, 0, 2), '0') + ((int) ltrim(substr($lon_deg, 2, 2), '0') / 60) + ((float) (ltrim(substr($lon_deg, 4, 2), '0').$lon_deg_dec) / 3600);
 					}
 
 					if (strlen($alt_deg) == 3) {        // [+-]DDD.D
-						$ISO6709parsed['altitude'] = (($alt_sign == '-') ? -1 : 1) * floatval(ltrim($alt_deg, '0').$alt_deg_dec);
+						$ISO6709parsed['altitude'] = (($alt_sign == '-') ? -1 : 1) * (float) (ltrim($alt_deg, '0').$alt_deg_dec);
 					} elseif (strlen($alt_deg) == 5) {  // [+-]DDDMM.M
-						$ISO6709parsed['altitude'] = (($alt_sign == '-') ? -1 : 1) * floatval(ltrim(substr($alt_deg, 0, 2), '0')) + floatval(ltrim(substr($alt_deg, 2, 2), '0').$alt_deg_dec / 60);
+						$ISO6709parsed['altitude'] = (($alt_sign == '-') ? -1 : 1) * (int) ltrim(substr($alt_deg, 0, 2), '0') + ((float) (ltrim(substr($alt_deg, 2, 2), '0').$alt_deg_dec) / 60);
 					} elseif (strlen($alt_deg) == 7) {  // [+-]DDDMMSS.S
-						$ISO6709parsed['altitude'] = (($alt_sign == '-') ? -1 : 1) * floatval(ltrim(substr($alt_deg, 0, 2), '0')) + floatval((int) ltrim(substr($alt_deg, 2, 2), '0') / 60) + floatval(ltrim(substr($alt_deg, 4, 2), '0').$alt_deg_dec / 3600);
+						$ISO6709parsed['altitude'] = (($alt_sign == '-') ? -1 : 1) * (int) ltrim(substr($alt_deg, 0, 2), '0') + ((int) ltrim(substr($alt_deg, 2, 2), '0') / 60) + ((float) (ltrim(substr($alt_deg, 4, 2), '0').$alt_deg_dec) / 3600);
 					}
 
 					foreach (array('latitude', 'longitude', 'altitude') as $key) {
@@ -802,7 +802,7 @@ class getid3_quicktime extends getid3_handler
 					}
 
 					$stsdEntriesDataOffset = 8;
-					for ($i = 0; $i < $atom_structure['number_entries']; $i++) {
+					for ($i = 0; $i < (int) $atom_structure['number_entries']; $i++) {
 						$atom_structure['sample_description_table'][$i]['size']             = getid3_lib::BigEndian2Int(substr($atom_data, $stsdEntriesDataOffset, 4));
 						$stsdEntriesDataOffset += 4;
 						$atom_structure['sample_description_table'][$i]['data_format']      =                           substr($atom_data, $stsdEntriesDataOffset, 4);
@@ -1979,16 +1979,16 @@ $this->warning('incomplete/incorrect handling of "stsd" with Parrot metadata in 
 									foreach (array('latitude','longitude') as $latlon) {
 										preg_match('#^([0-9]{1,3})([0-9]{2}\\.[0-9]+)$#', $GPS_this_GPRMC['raw'][$latlon], $matches);
 										list($dummy, $deg, $min) = $matches;
-										$GPS_this_GPRMC[$latlon] = $deg + ($min / 60);
+										$GPS_this_GPRMC[$latlon] = (int) $deg + ((float) $min / 60);
 									}
 									$GPS_this_GPRMC['latitude']  *= (($GPS_this_GPRMC['raw']['latitude_direction']  == 'S') ? -1 : 1);
 									$GPS_this_GPRMC['longitude'] *= (($GPS_this_GPRMC['raw']['longitude_direction'] == 'W') ? -1 : 1);
 
 									$GPS_this_GPRMC['heading']    = $GPS_this_GPRMC['raw']['angle'];
 									$GPS_this_GPRMC['speed_knot'] = $GPS_this_GPRMC['raw']['knots'];
-									$GPS_this_GPRMC['speed_kmh']  = $GPS_this_GPRMC['raw']['knots'] * 1.852;
+									$GPS_this_GPRMC['speed_kmh']  = (float) $GPS_this_GPRMC['raw']['knots'] * 1.852;
 									if ($GPS_this_GPRMC['raw']['variation']) {
-										$GPS_this_GPRMC['variation']  = $GPS_this_GPRMC['raw']['variation'];
+										$GPS_this_GPRMC['variation']  = (float) $GPS_this_GPRMC['raw']['variation'];
 										$GPS_this_GPRMC['variation'] *= (($GPS_this_GPRMC['raw']['variation_direction'] == 'W') ? -1 : 1);
 									}
 

--- a/getid3/module.audio-video.riff.php
+++ b/getid3/module.audio-video.riff.php
@@ -2034,7 +2034,7 @@ class getid3_riff extends getid3_handler
 		foreach ($RIFFinfoKeyLookup as $key => $value) {
 			if (isset($RIFFinfoArray[$key])) {
 				foreach ($RIFFinfoArray[$key] as $commentid => $commentdata) {
-					if (trim($commentdata['data']) != '') {
+					if (!empty($commentdata['data']) && trim($commentdata['data']) != '') {
 						if (isset($CommentsTargetArray[$value])) {
 							$CommentsTargetArray[$value][] =     trim($commentdata['data']);
 						} else {

--- a/getid3/module.audio-video.riff.php
+++ b/getid3/module.audio-video.riff.php
@@ -305,8 +305,8 @@ class getid3_riff extends getid3_handler
 						// assigned for text fields, resulting in a null-terminated string (or possibly just a single null) followed by garbage
 						// Keep only string as far as first null byte, discard rest of fixed-width data
 						// https://github.com/JamesHeinrich/getID3/issues/263
-						$null_terminator_offset = strpos($thisfile_riff_WAVE_bext_0[$bext_key], "\x00");
-						$thisfile_riff_WAVE_bext_0[$bext_key] = substr($thisfile_riff_WAVE_bext_0[$bext_key], 0, $null_terminator_offset);
+						// https://github.com/JamesHeinrich/getID3/issues/430
+						$thisfile_riff_WAVE_bext_0[$bext_key] = explode("\x00", $thisfile_riff_WAVE_bext_0[$bext_key])[0];
 					}
 
 					$thisfile_riff_WAVE_bext_0['origin_date']    =                              substr($thisfile_riff_WAVE_bext_0['data'], 320,  10);
@@ -1132,7 +1132,8 @@ class getid3_riff extends getid3_handler
 				$CommentsChunkNames = array('NAME'=>'title', 'author'=>'artist', '(c) '=>'copyright', 'ANNO'=>'comment');
 				foreach ($CommentsChunkNames as $key => $value) {
 					if (isset($thisfile_riff[$RIFFsubtype][$key][0]['data'])) {
-						$thisfile_riff['comments'][$value][] = $thisfile_riff[$RIFFsubtype][$key][0]['data'];
+						// https://github.com/JamesHeinrich/getID3/issues/430
+						$thisfile_riff['comments'][$value][] = explode("\x00", $thisfile_riff[$RIFFsubtype][$key][0]['data'])[0];
 					}
 				}
 /*
@@ -1224,7 +1225,8 @@ class getid3_riff extends getid3_handler
 				$CommentsChunkNames = array('NAME'=>'title', 'author'=>'artist', '(c) '=>'copyright', 'ANNO'=>'comment');
 				foreach ($CommentsChunkNames as $key => $value) {
 					if (isset($thisfile_riff[$RIFFsubtype][$key][0]['data'])) {
-						$thisfile_riff['comments'][$value][] = $thisfile_riff[$RIFFsubtype][$key][0]['data'];
+						// https://github.com/JamesHeinrich/getID3/issues/430
+						$thisfile_riff['comments'][$value][] = explode("\x00", $thisfile_riff[$RIFFsubtype][$key][0]['data'])[0];
 					}
 				}
 

--- a/getid3/module.audio-video.riff.php
+++ b/getid3/module.audio-video.riff.php
@@ -1366,19 +1366,19 @@ class getid3_riff extends getid3_handler
 		}
 
 		if ($info['playtime_seconds'] > 0) {
-			if (isset($thisfile_riff_audio) && isset($thisfile_riff_video)) {
+			if ($thisfile_riff_audio !== null && $thisfile_riff_video !== null) {
 
 				if (!isset($info['bitrate'])) {
 					$info['bitrate'] = ((($info['avdataend'] - $info['avdataoffset']) / $info['playtime_seconds']) * 8);
 				}
 
-			} elseif (isset($thisfile_riff_audio) && !isset($thisfile_riff_video)) {
+			} elseif ($thisfile_riff_audio !== null && $thisfile_riff_video === null) {
 
 				if (!isset($thisfile_audio['bitrate'])) {
 					$thisfile_audio['bitrate'] = ((($info['avdataend'] - $info['avdataoffset']) / $info['playtime_seconds']) * 8);
 				}
 
-			} elseif (!isset($thisfile_riff_audio) && isset($thisfile_riff_video)) {
+			} elseif ($thisfile_riff_audio === null && $thisfile_riff_video !== null) {
 
 				if (!isset($thisfile_video['bitrate'])) {
 					$thisfile_video['bitrate'] = ((($info['avdataend'] - $info['avdataoffset']) / $info['playtime_seconds']) * 8);
@@ -1695,7 +1695,7 @@ class getid3_riff extends getid3_handler
 							break;
 						}
 						$thisindex = 0;
-						if (isset($RIFFchunk[$chunkname]) && is_array($RIFFchunk[$chunkname])) {
+						if (isset($RIFFchunk[$chunkname])) {
 							$thisindex = count($RIFFchunk[$chunkname]);
 						}
 						$RIFFchunk[$chunkname][$thisindex]['offset'] = $this->ftell() - 8;

--- a/getid3/module.audio-video.riff.php
+++ b/getid3/module.audio-video.riff.php
@@ -306,7 +306,8 @@ class getid3_riff extends getid3_handler
 						// Keep only string as far as first null byte, discard rest of fixed-width data
 						// https://github.com/JamesHeinrich/getID3/issues/263
 						// https://github.com/JamesHeinrich/getID3/issues/430
-						$thisfile_riff_WAVE_bext_0[$bext_key] = explode("\x00", $thisfile_riff_WAVE_bext_0[$bext_key])[0];
+						$null_terminator_rows = explode("\x00", $thisfile_riff_WAVE_bext_0[$bext_key]);
+						$thisfile_riff_WAVE_bext_0[$bext_key] = $null_terminator_rows[0];
 					}
 
 					$thisfile_riff_WAVE_bext_0['origin_date']    =                              substr($thisfile_riff_WAVE_bext_0['data'], 320,  10);
@@ -1133,7 +1134,8 @@ class getid3_riff extends getid3_handler
 				foreach ($CommentsChunkNames as $key => $value) {
 					if (isset($thisfile_riff[$RIFFsubtype][$key][0]['data'])) {
 						// https://github.com/JamesHeinrich/getID3/issues/430
-						$thisfile_riff['comments'][$value][] = explode("\x00", $thisfile_riff[$RIFFsubtype][$key][0]['data'])[0];
+						$null_terminator_rows = explode("\x00", $thisfile_riff[$RIFFsubtype][$key][0]['data']);
+						$thisfile_riff['comments'][$value][] = $null_terminator_rows[0];
 					}
 				}
 /*
@@ -1226,7 +1228,8 @@ class getid3_riff extends getid3_handler
 				foreach ($CommentsChunkNames as $key => $value) {
 					if (isset($thisfile_riff[$RIFFsubtype][$key][0]['data'])) {
 						// https://github.com/JamesHeinrich/getID3/issues/430
-						$thisfile_riff['comments'][$value][] = explode("\x00", $thisfile_riff[$RIFFsubtype][$key][0]['data'])[0];
+						$null_terminator_rows = explode("\x00", $thisfile_riff[$RIFFsubtype][$key][0]['data']);
+						$thisfile_riff['comments'][$value][] = $null_terminator_rows[0];
 					}
 				}
 

--- a/getid3/module.audio.dss.php
+++ b/getid3/module.audio.dss.php
@@ -83,11 +83,11 @@ class getid3_dss extends getid3_handler
 	 */
 	public function DSSdateStringToUnixDate($datestring) {
 		$y = (int) substr($datestring,  0, 2);
-		$m = substr($datestring,  2, 2);
-		$d = substr($datestring,  4, 2);
-		$h = substr($datestring,  6, 2);
-		$i = substr($datestring,  8, 2);
-		$s = substr($datestring, 10, 2);
+		$m = (int) substr($datestring,  2, 2);
+		$d = (int) substr($datestring,  4, 2);
+		$h = (int) substr($datestring,  6, 2);
+		$i = (int) substr($datestring,  8, 2);
+		$s = (int) substr($datestring, 10, 2);
 		$y += (($y < 95) ? 2000 : 1900);
 		return mktime($h, $i, $s, $m, $d, $y);
 	}

--- a/getid3/module.audio.midi.php
+++ b/getid3/module.audio.midi.php
@@ -111,7 +111,7 @@ class getid3_midi extends getid3_handler
 				$TicksAtCurrentBPM = 0;
 				while ($eventsoffset < strlen($trackdata)) {
 					$eventid = 0;
-					if (isset($MIDIevents[$tracknumber]) && is_array($MIDIevents[$tracknumber])) {
+					if (isset($MIDIevents[$tracknumber])) {
 						$eventid = count($MIDIevents[$tracknumber]);
 					}
 					$deltatime = 0;

--- a/getid3/module.graphic.png.php
+++ b/getid3/module.graphic.png.php
@@ -137,7 +137,7 @@ class getid3_png extends getid3_handler
 
 				case 'tRNS': // Transparency
 					$thisfile_png_chunk_type_text['header'] = $chunk;
-					switch ($thisfile_png['IHDR']['raw']['color_type']) {
+					switch ($thisfile_png['IHDR']['raw']['color_type']) { // @phpstan-ignore-line
 						case 0:
 							$thisfile_png_chunk_type_text['transparent_color_gray']  = getid3_lib::BigEndian2Int(substr($chunk['data'], 0, 2));
 							break;
@@ -160,7 +160,7 @@ class getid3_png extends getid3_handler
 							break;
 
 						default:
-							$this->warning('Unhandled color_type in tRNS chunk: '.$thisfile_png['IHDR']['raw']['color_type']);
+							$this->warning('Unhandled color_type in tRNS chunk: '.$thisfile_png['IHDR']['raw']['color_type']); // @phpstan-ignore-line
 							break;
 					}
 					break;
@@ -273,7 +273,7 @@ class getid3_png extends getid3_handler
 
 				case 'bKGD': // Background Color
 					$thisfile_png_chunk_type_text['header']                   = $chunk;
-					switch ($thisfile_png['IHDR']['raw']['color_type']) {
+					switch ($thisfile_png['IHDR']['raw']['color_type']) { // @phpstan-ignore-line
 						case 0:
 						case 4:
 							$thisfile_png_chunk_type_text['background_gray']  = getid3_lib::BigEndian2Int($chunk['data']);
@@ -307,7 +307,7 @@ class getid3_png extends getid3_handler
 
 				case 'sBIT': // Significant Bits
 					$thisfile_png_chunk_type_text['header'] = $chunk;
-					switch ($thisfile_png['IHDR']['raw']['color_type']) {
+					switch ($thisfile_png['IHDR']['raw']['color_type']) { // @phpstan-ignore-line
 						case 0:
 							$thisfile_png_chunk_type_text['significant_bits_gray']  = getid3_lib::BigEndian2Int(substr($chunk['data'], 0, 1));
 							break;
@@ -422,10 +422,7 @@ class getid3_png extends getid3_handler
 
 
 				case 'gIFg': // GIF Graphic Control Extension
-					$gIFgCounter = 0;
-					if (isset($thisfile_png_chunk_type_text) && is_array($thisfile_png_chunk_type_text)) {
-						$gIFgCounter = count($thisfile_png_chunk_type_text);
-					}
+					$gIFgCounter = count($thisfile_png_chunk_type_text);
 					$thisfile_png_chunk_type_text[$gIFgCounter]['header']          = $chunk;
 					$thisfile_png_chunk_type_text[$gIFgCounter]['disposal_method'] = getid3_lib::BigEndian2Int(substr($chunk['data'], 0, 1));
 					$thisfile_png_chunk_type_text[$gIFgCounter]['user_input_flag'] = getid3_lib::BigEndian2Int(substr($chunk['data'], 1, 1));
@@ -434,10 +431,7 @@ class getid3_png extends getid3_handler
 
 
 				case 'gIFx': // GIF Application Extension
-					$gIFxCounter = 0;
-					if (isset($thisfile_png_chunk_type_text) && is_array($thisfile_png_chunk_type_text)) {
-						$gIFxCounter = count($thisfile_png_chunk_type_text);
-					}
+					$gIFxCounter = count($thisfile_png_chunk_type_text);
 					$thisfile_png_chunk_type_text[$gIFxCounter]['header']                 = $chunk;
 					$thisfile_png_chunk_type_text[$gIFxCounter]['application_identifier'] = substr($chunk['data'],  0, 8);
 					$thisfile_png_chunk_type_text[$gIFxCounter]['authentication_code']    = substr($chunk['data'],  8, 3);
@@ -446,10 +440,7 @@ class getid3_png extends getid3_handler
 
 
 				case 'IDAT': // Image Data
-					$idatinformationfieldindex = 0;
-					if (isset($thisfile_png['IDAT']) && is_array($thisfile_png['IDAT'])) {
-						$idatinformationfieldindex = count($thisfile_png['IDAT']);
-					}
+					$idatinformationfieldindex = count($thisfile_png['IDAT']);
 					unset($chunk['data']);
 					$thisfile_png_chunk_type_text[$idatinformationfieldindex]['header'] = $chunk;
 					break;

--- a/getid3/module.misc.gpx.php
+++ b/getid3/module.misc.gpx.php
@@ -1,0 +1,36 @@
+<?php
+
+/////////////////////////////////////////////////////////////////
+/// getID3() by James Heinrich <info@getid3.org>               //
+//  available at https://github.com/JamesHeinrich/getID3       //
+//            or https://www.getid3.org                        //
+//            or http://getid3.sourceforge.net                 //
+//  see readme.txt for more details                            //
+/////////////////////////////////////////////////////////////////
+//                                                             //
+// module.misc.gpx.php                                        //
+// module for analyzing gpx files                             //
+// dependencies: NONE                                          //
+//                                                            ///
+/////////////////////////////////////////////////////////////////
+
+if (!defined('GETID3_INCLUDEPATH')) { // prevent path-exposing attacks that access modules directly on public webservers
+	exit;
+}
+
+class getid3_gpx extends getid3_handler
+{
+	/**
+	 * @return bool
+	 */
+	public function Analyze() {
+		$info = &$this->getid3->info;
+
+		$info['fileformat'] = 'gpx';
+
+		$this->error('gpx parsing not enabled in this version of getID3()');
+		return false;
+
+	}
+
+}

--- a/getid3/module.tag.apetag.php
+++ b/getid3/module.tag.apetag.php
@@ -42,6 +42,10 @@ class getid3_apetag extends getid3_handler
 			$this->warning('Unable to check for APEtags because file is larger than '.round(PHP_INT_MAX / 1073741824).'GB');
 			return false;
 		}
+		if (PHP_INT_MAX == 2147483647) {
+			// https://github.com/JamesHeinrich/getID3/issues/439
+			$this->warning('APEtag flags may not be parsed correctly on 32-bit PHP');
+		}
 
 		$id3v1tagsize     = 128;
 		$apetagheadersize = 32;

--- a/getid3/module.tag.id3v2.php
+++ b/getid3/module.tag.id3v2.php
@@ -1304,7 +1304,7 @@ class getid3_id3v2 extends getid3_handler
 			// Adjustment            $xx (xx ...)
 
 			$frame_offset = 0;
-			$parsedFrame['adjustmentbits'] = substr($parsedFrame['data'], $frame_offset++, 1);
+			$parsedFrame['adjustmentbits'] = ord(substr($parsedFrame['data'], $frame_offset++, 1));
 			$frame_adjustmentbytes = ceil($parsedFrame['adjustmentbits'] / 8);
 
 			$frame_remainingdata = (string) substr($parsedFrame['data'], $frame_offset);

--- a/getid3/module.tag.lyrics3.php
+++ b/getid3/module.tag.lyrics3.php
@@ -272,7 +272,7 @@ class getid3_lyrics3 extends getid3_handler
 	 */
 	public function Lyrics3Timestamp2Seconds($rawtimestamp) {
 		if (preg_match('#^\\[([0-9]{2}):([0-9]{2})\\]$#', $rawtimestamp, $regs)) {
-			return (int) (($regs[1] * 60) + $regs[2]);
+			return (int) (((int) $regs[1] * 60) + (int) $regs[2]);
 		}
 		return false;
 	}

--- a/getid3/write.id3v2.php
+++ b/getid3/write.id3v2.php
@@ -250,7 +250,7 @@ class getid3_write_id3v2
 						fwrite($fp_temp, $buffer, strlen($buffer));
 					}
 					fclose($fp_source);
-					if (getID3::is_writable($this->filename) && ($fp_source = fopen($this->filename, 'wb'))) {
+					if ($fp_source = fopen($this->filename, 'wb')) {
 						rewind($fp_temp);
 						while ($buffer = fread($fp_temp, $this->fread_buffer_size)) {
 							fwrite($fp_source, $buffer, strlen($buffer));


### PR DESCRIPTION
1.29.24 prerelease
* JamesHeinrich#429 libxml_disable_entity_loader is deprecated
* JamesHeinrich#430 RIFF only return comment string up to first null
* JamesHeinrich#434 do not crash on empty seconds in DSS module
* JamesHeinrich#435 Compatibility fix for PHP 5.3
* JamesHeinrich#436 Update deprecated actions/checkout; lint against PHP 8.4
* JamesHeinrich#437 Upgrade PHPStan to v1.10.57
* JamesHeinrich#438 basic GPX format detection
* APE 32-bit PHP warning
* JamesHeinrich#440 Mpeg duration error due to error in GOP parsing
* JamesHeinrich#442 Warning on PrintHexBytes function when $string is not a string